### PR TITLE
Add Django 1.10.1 to requirements.txt for example

### DIFF
--- a/example/jspm_0_17/requirements.txt
+++ b/example/jspm_0_17/requirements.txt
@@ -1,1 +1,2 @@
+django==1.10.1
 django-systemjs==1.3.2


### PR DESCRIPTION
Hi, I was trying to run the examples and I noticed that django wasn't in the requirements so it wasn't running. I've added version 1.10.1 in this PR!